### PR TITLE
updated default-resources

### DIFF
--- a/mpi-ie-slurm/config.yaml
+++ b/mpi-ie-slurm/config.yaml
@@ -10,8 +10,8 @@ cluster-status: status-scontrol.sh
 conda-prefix: /package/mamba/envs/pore-c-mpi_envs
 default-resources:
 - partition=bioinfo
-- mem_mb=2400
-- disk_mb=2400
+- mem_mb=4800
+- disk_mb=4800
 - logdir=logs
 jobscript: slurm-jobscript.sh
 keep-going: true


### PR DESCRIPTION
I added more mem_mb and disk_mb to the mpi-ie-slurm config.yaml file as it was needed to run with large fastq files